### PR TITLE
Catalogue extender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spot"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://github.com/samply/spot"
@@ -20,7 +20,7 @@ once_cell = "1"
 # Logging
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-reqwest = { version = "0.11.20", default-features = false, features = ["stream"] }
+reqwest = { version = "0.11.20", default-features = false, features = ["stream", "default-tls"] }
 tower-http = { version = "0.4.4", features = ["cors"] }
 
 [build-dependencies]

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -10,7 +10,7 @@ pub(crate) fn print_banner() {
         _ => "SNAPSHOT",
     };
     info!(
-        "🌈 Samply.Spot v{} (built {} {}, {}) starting up ...",
+        "🌈 Samply.Spot v{} (built {} {}, {}) ready to take requests.",
         env!("CARGO_PKG_VERSION"),
         env!("BUILD_DATE"),
         env!("BUILD_TIME"),

--- a/src/catalogue.rs
+++ b/src/catalogue.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -25,8 +27,13 @@ struct ChildCategory {
 
 pub async fn get_extended_json(catalogue_url: Url) -> Value {
     debug!("Fetching catalogue from {catalogue_url} ...");
-    let resp = reqwest::get(catalogue_url).await
-        .expect("Unable to fetch catalogue from upstream; please check URL specified in config.");
+
+    let resp = reqwest::Client::new()
+    .get(catalogue_url)
+    .timeout(Duration::from_secs(30))
+    .send()
+    .await
+    .expect("Unable to fetch catalogue from upstream; please check URL specified in config.");
 
     let mut json: Value = resp.json().await
         .expect("Unable to parse catalogue from upstream; please check URL specified in config.");

--- a/src/catalogue.rs
+++ b/src/catalogue.rs
@@ -44,12 +44,7 @@ pub async fn get_extended_json(catalogue_url: Url, prism_url: Url) -> Value {
     let mut counts: CriteriaGroups = prism_resp.json().await
     .expect("Unable to parse response from Prism into CriteriaGroups");
 
-
-    //dbg!(&counts);
-
     recurse(&mut json, &mut counts); //TODO remove from counts once copied into catalogue to make it O(n log n)
-
-    //println!("{}", serde_json::to_string_pretty(&json).unwrap());
 
     info!("Catalogue built successfully.");
 
@@ -79,6 +74,7 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
                 let group_key = obj.get("key").expect("Got JSON element with childCategories but without (group) key. Please check json.").as_str()
                 .expect("Got JSON where a criterion key was not a string. Please check json.").to_owned();
 
+                //TODO consolidate catalogue and MeasureReport group names
                 let group_key = if group_key == "patient" {"patients"} 
                 else if group_key == "tumor_classification" {"diagnosis"} 
                 else if group_key == "biosamples" {"specimen"}

--- a/src/catalogue.rs
+++ b/src/catalogue.rs
@@ -56,16 +56,13 @@ pub async fn get_extended_json(catalogue_url: Url, prism_url: Url) -> Value {
 ///                \-- stratum key (e.g. male, other)
 fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
     match json {
-        Value::Null => (),
-        Value::Bool(_) => (),
-        Value::Number(_) => (),
-        Value::String(_) => (),
         Value::Array(arr) => {
             for ele in arr {
                 recurse(ele, counts);
             }
         },
         Value::Object(obj) => {
+            
             if ! obj.contains_key("childCategories") {
                 for (_key, child_val) in obj.iter_mut() {
                     recurse(child_val, counts);
@@ -120,5 +117,6 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
                 }
             }
         },
+        _ => {}
     }
 }

--- a/src/catalogue.rs
+++ b/src/catalogue.rs
@@ -11,38 +11,46 @@ pub type CriteriaGroup = BTreeMap<String, Criteria>;
 
 pub type CriteriaGroups = BTreeMap<String, CriteriaGroup>;
 
-fn get_element<'a>(count: &'a CriteriaGroups, key1: &'a str, key2: &'a str, key3: &'a str) -> Option<&'a u64> {
-    count.get(key1)
+fn get_element<'a>(
+    count: &'a CriteriaGroups,
+    key1: &'a str,
+    key2: &'a str,
+    key3: &'a str,
+) -> Option<&'a u64> {
+    count
+        .get(key1)
         .and_then(|group| group.get(key2))
         .and_then(|criteria| criteria.get(key3))
 }
-
 
 pub async fn get_extended_json(catalogue_url: Url, prism_url: Url) -> Value {
     debug!("Fetching catalogue from {catalogue_url} ...");
 
     let resp = reqwest::Client::new()
-    .get(catalogue_url)
-    .timeout(Duration::from_secs(30))
-    .send()
-    .await
-    .expect("Unable to fetch catalogue from upstream; please check URL specified in config.");
+        .get(catalogue_url)
+        .timeout(Duration::from_secs(30))
+        .send()
+        .await
+        .expect("Unable to fetch catalogue from upstream; please check URL specified in config.");
 
-    let mut json: Value = resp.json().await
+    let mut json: Value = resp
+        .json()
+        .await
         .expect("Unable to parse catalogue from upstream; please check URL specified in config.");
 
-
     let prism_resp = reqwest::Client::new()
-    .post(format!("{}criteria", prism_url))
-    .header("Content-Type", "application/json")
-    .body("{\"sites\": []}")
-    .timeout(Duration::from_secs(300))
-    .send()
-    .await
-    .expect("Unable to fetch response from Prism; please check it's running.");
+        .post(format!("{}criteria", prism_url))
+        .header("Content-Type", "application/json")
+        .body("{\"sites\": []}")
+        .timeout(Duration::from_secs(300))
+        .send()
+        .await
+        .expect("Unable to fetch response from Prism; please check it's running.");
 
-    let mut counts: CriteriaGroups = prism_resp.json().await
-    .expect("Unable to parse response from Prism into CriteriaGroups");
+    let mut counts: CriteriaGroups = prism_resp
+        .json()
+        .await
+        .expect("Unable to parse response from Prism into CriteriaGroups");
 
     recurse(&mut json, &mut counts); //TODO remove from counts once copied into catalogue to make it O(n log n)
 
@@ -60,10 +68,9 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
             for ele in arr {
                 recurse(ele, counts);
             }
-        },
+        }
         Value::Object(obj) => {
-            
-            if ! obj.contains_key("childCategories") {
+            if !obj.contains_key("childCategories") {
                 for (_key, child_val) in obj.iter_mut() {
                     recurse(child_val, counts);
                 }
@@ -72,10 +79,15 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
                 .expect("Got JSON where a criterion key was not a string. Please check json.").to_owned();
 
                 //TODO consolidate catalogue and MeasureReport group names
-                let group_key = if group_key == "patient" {"patients"} 
-                else if group_key == "tumor_classification" {"diagnosis"} 
-                else if group_key == "biosamples" {"specimen"}
-                else {&group_key};
+                let group_key = if group_key == "patient" {
+                    "patients"
+                } else if group_key == "tumor_classification" {
+                    "diagnosis"
+                } else if group_key == "biosamples" {
+                    "specimen"
+                } else {
+                    &group_key
+                };
 
                 let children_cats = obj
                     .get_mut("childCategories")
@@ -84,7 +96,7 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
                     .unwrap()
                     .iter_mut()
                     .filter(|item| item.get("type").unwrap_or(&Value::Null) == "EQUALS");
-                
+
                 for child_cat in children_cats {
                     let stratifier_key = child_cat.get("key").expect("Got JSON element with childCategory that does not contain a (stratifier) key. Please check json.").as_str()
                     .expect("Got JSON where a criterion key was not a string. Please check json.").to_owned();
@@ -96,27 +108,32 @@ fn recurse(json: &mut Value, counts: &mut CriteriaGroups) {
                         .expect("Got JSON element with childCategory with criteria that are not an array. Please check json.");
 
                     for criterion in criteria {
-                        let criterion = criterion.as_object_mut()
-                            .expect("Got JSON where a criterion was not an object. Please check json.");
+                        let criterion = criterion.as_object_mut().expect(
+                            "Got JSON where a criterion was not an object. Please check json.",
+                        );
                         let stratum_key = criterion.get("key")
                             .expect("Got JSON where a criterion did not have a key. Please check json.")
                             .as_str()
                             .expect("Got JSON where a criterion key was not a string. Please check json.");
-                        
-                        let count_from_prism = get_element(counts, &group_key, &stratifier_key, stratum_key);
+
+                        let count_from_prism =
+                            get_element(counts, &group_key, &stratifier_key, stratum_key);
 
                         match count_from_prism {
                             Some(count) => {
                                 criterion.insert("count".into(), json!(count));
-                            },
-                            None => {
-                                debug!("No count from Prism for {}, {}, {}", group_key, stratifier_key, stratum_key);
                             }
-                        }                        
+                            None => {
+                                debug!(
+                                    "No count from Prism for {}, {}, {}",
+                                    group_key, stratifier_key, stratum_key
+                                );
+                            }
+                        }
                     }
                 }
             }
-        },
+        }
         _ => {}
     }
 }

--- a/src/catalogue.rs
+++ b/src/catalogue.rs
@@ -1,0 +1,100 @@
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tracing::{debug, info};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum ChildCategoryType {
+    Equals,
+    SomethingElse
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChildCategoryCriterion {
+    key: String,
+    count: Option<usize>
+}
+
+#[derive(Serialize, Deserialize)]
+struct ChildCategory {
+    key: String,
+    type_: ChildCategoryType,
+    criteria: Vec<ChildCategoryCriterion>
+}
+
+pub async fn get_extended_json(catalogue_url: Url) -> Value {
+    debug!("Fetching catalogue from {catalogue_url} ...");
+    let resp = reqwest::get(catalogue_url).await
+        .expect("Unable to fetch catalogue from upstream; please check URL specified in config.");
+
+    let mut json: Value = resp.json().await
+        .expect("Unable to parse catalogue from upstream; please check URL specified in config.");
+
+    // TODO: Query prism for counts here.
+
+    recurse(&mut json);
+
+    // println!("{}", serde_json::to_string_pretty(&json).unwrap());
+
+    info!("Catalogue built successfully.");
+
+    json
+}
+
+/// Key order: group key (e.g. patient)
+///            \-- stratifier key (e.g. admin_gender)
+///                \-- stratum key (e.g. male, other)
+fn recurse(json: &mut Value) {
+    match json {
+        Value::Null => (),
+        Value::Bool(_) => (),
+        Value::Number(_) => (),
+        Value::String(_) => (),
+        Value::Array(arr) => {
+            for ele in arr {
+                recurse(ele);
+            }
+        },
+        Value::Object(obj) => {
+            if ! obj.contains_key("childCategories") {
+                for (_key, child_val) in obj.iter_mut() {
+                    recurse(child_val);
+                }
+            } else {
+                let group_key = obj.get("key").expect("Got JSON element with childCategories but without (group) key. Please check json.");
+
+                let children_cats = obj
+                    .get_mut("childCategories")
+                    .unwrap()
+                    .as_array_mut()
+                    .unwrap()
+                    .iter_mut()
+                    .filter(|item| item.get("type").unwrap_or(&Value::Null) == "EQUALS");
+                
+                for child_cat in children_cats {
+                    let stratifier_key = child_cat.get("key").expect("Got JSON element with childCategory that does not contain a (stratifier) key. Please check json.");
+                    let criteria = child_cat
+                        .get_mut("criteria")
+                        .expect("Got JSON element with childCategory that does not contain a criteria array. Please check json.")
+                        .as_array_mut()
+                        .expect("Got JSON element with childCategory with criteria that are not an array. Please check json.");
+
+                    for criterion in criteria {
+                        let criterion = criterion.as_object_mut()
+                            .expect("Got JSON where a criterion was not an object. Please check json.");
+                        let stratum_key = criterion.get("key")
+                            .expect("Got JSON where a criterion did not have a key. Please check json.")
+                            .as_str()
+                            .expect("Got JSON where a criterion key was not a string. Please check json.");
+                        
+                        // fetch from Prism output
+                        let count_from_prism = 10;
+
+                        criterion.insert("count".into(), json!(count_from_prism));
+                    }
+                }
+            }
+        },
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,12 +29,16 @@ pub struct Config {
     pub project: Option<String>,
 
     /// The socket address this server will bind to
-    #[clap(long, env, default_value = "0.0.0.0:8080")]
+    #[clap(long, env, default_value = "0.0.0.0:8055")]
     pub bind_addr: SocketAddr,
 
     /// URL to catalogue.json file
     #[clap(long, env)]
-    pub catalogue_url: Url
+    pub catalogue_url: Url,
+
+    /// URL to prism
+    #[clap(long, env, default_value= "http://localhost:8066")]
+    pub prism_url: Url
 }
 
 fn parse_cors(v: &str) -> Result<AllowOrigin, InvalidHeaderValue> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,10 @@ pub struct Config {
     /// The socket address this server will bind to
     #[clap(long, env, default_value = "0.0.0.0:8080")]
     pub bind_addr: SocketAddr,
+
+    /// URL to catalogue.json file
+    #[clap(long, env)]
+    pub catalogue_url: Url
 }
 
 fn parse_cors(v: &str) -> Result<AllowOrigin, InvalidHeaderValue> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,12 @@ async fn main() {
         .with_env_filter(EnvFilter::from_default_env())
         .finish()
         .init();
-    banner::print_banner();
+
     info!("{:#?}", Lazy::force(&CONFIG));
+
+    
+
+    banner::print_banner();
     // TODO: Add check for reachability of beam-proxy
 
     let cors = CorsLayer::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tower_http::cors::CorsLayer;
 use tracing::{info, warn, Level};
-use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
+use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 
 mod banner;
 mod beam;
@@ -34,7 +34,7 @@ static BEAM_CLIENT: Lazy<BeamClient> = Lazy::new(|| {
 
 #[derive(Clone)]
 struct SharedState {
-    extended_json: Value
+    extended_json: Value,
 }
 
 #[tokio::main]
@@ -47,7 +47,8 @@ async fn main() {
 
     info!("{:#?}", Lazy::force(&CONFIG));
 
-    let extended_json = catalogue::get_extended_json(CONFIG.catalogue_url.clone(), CONFIG.prism_url.clone()).await;
+    let extended_json =
+        catalogue::get_extended_json(CONFIG.catalogue_url.clone(), CONFIG.prism_url.clone()).await;
     let state = SharedState { extended_json };
 
     // TODO: Add check for reachability of beam-proxy
@@ -117,7 +118,10 @@ async fn handle_listen_to_beam_tasks(
         .send()
         .await
         .map_err(|err| {
-            println!("Failed request to {} with error: {}", CONFIG.beam_proxy_url, err);
+            println!(
+                "Failed request to {} with error: {}",
+                CONFIG.beam_proxy_url, err
+            );
             (
                 StatusCode::BAD_GATEWAY,
                 format!("Error calling beam, check the server logs."),
@@ -145,8 +149,6 @@ fn convert_response(response: reqwest::Response) -> axum::response::Response {
         .into_response()
 }
 
-async fn handle_get_catalogue(
-    State(state): State<SharedState>
-) -> Json<Value> {
+async fn handle_get_catalogue(State(state): State<SharedState>) -> Json<Value> {
     Json(state.extended_json)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
 
     info!("{:#?}", Lazy::force(&CONFIG));
 
-    let extended_json = catalogue::get_extended_json(CONFIG.catalogue_url.clone()).await;
+    let extended_json = catalogue::get_extended_json(CONFIG.catalogue_url.clone(), CONFIG.prism_url.clone()).await;
     let state = SharedState { extended_json };
 
     // TODO: Add check for reachability of beam-proxy

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Json, Path, Query},
+    extract::{Json, Path, Query, State},
     http::HeaderValue,
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -12,12 +12,14 @@ use config::Config;
 use once_cell::sync::Lazy;
 use reqwest::{header, Method, StatusCode};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tower_http::cors::CorsLayer;
 use tracing::{info, warn, Level};
 use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
 
 mod banner;
 mod beam;
+mod catalogue;
 mod config;
 
 static CONFIG: Lazy<Config> = Lazy::new(Config::parse);
@@ -30,6 +32,11 @@ static BEAM_CLIENT: Lazy<BeamClient> = Lazy::new(|| {
     )
 });
 
+#[derive(Clone)]
+struct SharedState {
+    extended_json: Value
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::FmtSubscriber::builder()
@@ -40,9 +47,9 @@ async fn main() {
 
     info!("{:#?}", Lazy::force(&CONFIG));
 
-    
+    let extended_json = catalogue::get_extended_json(CONFIG.catalogue_url.clone()).await;
+    let state = SharedState { extended_json };
 
-    banner::print_banner();
     // TODO: Add check for reachability of beam-proxy
 
     let cors = CorsLayer::new()
@@ -53,8 +60,12 @@ async fn main() {
     let app = Router::new()
         .route("/beam", post(handle_create_beam_task))
         .route("/beam/:task_id", get(handle_listen_to_beam_tasks))
+        .route("/catalogue", get(handle_get_catalogue))
+        .with_state(state)
         .layer(axum::middleware::map_response(banner::set_server_header))
         .layer(cors);
+
+    banner::print_banner();
 
     axum::Server::bind(&CONFIG.bind_addr)
         .serve(app.into_make_service())
@@ -132,4 +143,10 @@ fn convert_response(response: reqwest::Response) -> axum::response::Response {
         // Same goes for this unwrap
         .unwrap()
         .into_response()
+}
+
+async fn handle_get_catalogue(
+    State(state): State<SharedState>
+) -> Json<Value> {
+    Json(state.extended_json)
 }


### PR DESCRIPTION
because stratifier groups are named differently in the catalogue and in the Measure, and their obfuscation depends on their names in the Measure, I didn't want to change their names in the Measure in Prism, so I had to rename them when searching in Prism response

"patient" => "patients"
"tumor_classification" => "diagnosis" 
"biosamples" => "specimen"

Please @torbrenner confirm that those names from catalogue correspond to those names from MeasureReport.