### PR TITLE
feat: auto remove invalid receivers from task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustyspot"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "Apache-2.0"
 documentation = "https://github.com/samply/spot"


### PR DESCRIPTION
Open question:
- Should we modify our response in any way to let the client know we removed some senders?