### PR TITLE
Flush log file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,10 @@ async fn log_query(log_file: &PathBuf, query: LensQuery, headers: HeaderMap, res
         .append(true)
         .create(true)
         .open(log_file)
-        .and_then(|mut f| async move { f.write(&out).await })
+        .and_then(|mut f| async move {
+            f.write(&out).await?;
+            f.flush().await
+        })
         .await;
     if let Err(e) = res {
         warn!("Failed to write to log file: {e}");


### PR DESCRIPTION
Because the log file is buffered you can't really `tail -f` it to test it. I think log files shouldn't be buffered in general.

I was too lazy to test this. You think it could break anything?