### PR TITLE
Handle SIGTERM for proper shutdown in Docker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,24 @@ async fn main() {
     banner::print_banner();
 
     axum::serve(TcpListener::bind(CONFIG.bind_addr).await.unwrap(), app.into_make_service())
+        .with_graceful_shutdown(wait_for_shutdown())
         .await
         .unwrap();
+}
+
+async fn wait_for_shutdown() {
+    #[cfg(unix)]
+    {
+        // Required for proper shutdown in Docker
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
+        sigterm.recv().await.expect("Failed to receive SIGTERM");
+        info!("Received SIGTERM, shutting down...");
+        return
+    }
+    // On other platforms we let the OS handle the shutdown
+    #[cfg(not(unix))]
+    std::future::pending::<()>().await;
 }
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
For some reason we need to explicitly handle SIGTERM for proper shutdown in Docker. Before this PR `docker stop` or `docker compose down` timed out for 10 seconds and then forcefully killed the container.