### PR TITLE
Add endpoint /prism/criteria endpoint that forwards to prism and logs…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -282,10 +282,10 @@ async fn handle_prism_criteria(
     headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    let client = reqwest::Client::new();
+    static CLIENT: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(reqwest::Client::new);
     let base = CONFIG.prism_url.to_string();
     let url = format!("{}/criteria", base.trim_end_matches('/'));
-    let resp = client
+    let resp = CLIENT
         .post(&url)
         .headers(headers.clone())
         .body(body.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,6 @@ async fn handle_create_beam_task(
         let log_file = log_file.clone();
         let result_log_sender_map = result_log_sender_map.clone();
         tokio::spawn(async move {
-            // Old log_query logic, but now with type="query"
             let (tx, mut rx) = mpsc::channel(q.sites.len());
             result_log_sender_map.lock().await.insert(q.id, tx);
             let mut results = Vec::with_capacity(q.sites.len());


### PR DESCRIPTION
Martin decided that prism should not be exposed to the internet and instead sit behind spot. This PR adds `/prism/criteria` endpoint to spot that forwards the request to prism. It also logs the request into the same log file as the regular queries.