### PR TITLE
Fix query filter parsing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct Config {
     pub target_app: String,
 
     /// Comma separated list of base64 encoded queries
-    #[clap(long, env, value_parser = parse_query_filter)]
+    #[clap(long, env, value_parser, value_delimiter = ',')]
     pub query_filter: Option<Vec<String>>,
 }
 
@@ -59,8 +59,4 @@ fn parse_cors(v: &str) -> Result<AllowOrigin, InvalidHeaderValue> {
     } else {
         v.parse().map(AllowOrigin::exact)
     }
-}
-
-fn parse_query_filter(v: &str) -> Result<Vec<String>, Infallible> {
-    Ok(v.split(',').map(String::from).collect())
 }


### PR DESCRIPTION
I just got the weirdest error

```
spot-internal-1  | thread 'main' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/clap_builder-4.5.40/src/parser/error.rs:32:9:
spot-internal-1  | Mismatch between definition and access of `query_filter`. Could not downcast to TypeId(0x97c618b939b0bcc8a17d448b0f209e61), need to downcast to TypeId(0xcb3f22921f468ebadeae21c1f45893d0)
```

This seemed to fix it for me locally although I am not sure why. It think it's a good change anyways.