### PR TITLE
Return HTTP 400 when sites list is empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,10 @@ async fn handle_create_beam_task(
     headers: HeaderMap,
     Json(query): Json<LensQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, &'static str)> {
+    if query.sites.is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "No sites specified"));
+    }
+
     if let Some(log_file) = &CONFIG.log_file {
         let q = query.clone();
         let h = headers.clone();


### PR DESCRIPTION
Spot used to crash here

https://github.com/samply/spot/blob/ed596bcbbedb9f58296bd5feb198cb845e63483e/src/main.rs#L144

when sites list was empty because `mpsc::channel` panics if you pass 0.